### PR TITLE
Fix for failure on clone

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "shFlags"]
 	path = shFlags
-	url = git://github.com/nvie/shFlags.git
+	url = https://github.com/nvie/shFlags.git

--- a/README.mdown
+++ b/README.mdown
@@ -48,7 +48,7 @@ If you're on a Mac and use [homebrew](http://github.com/mxcl/homebrew), it's sim
 ### Manual installation
 If you prefer a manual installation, please use the following instructions:
 
-    $ git clone --recursive git://github.com/iwata/git-now.git
+    $ git clone --recursive https://github.com/iwata/git-now.git
 
 #### for Windows
 Then, you can install `git-now`, using:


### PR DESCRIPTION
When I ran clone, it failed as follows, so I changed the URL.

<img width="753" alt="image" src="https://user-images.githubusercontent.com/11070996/161871419-d807636b-f84b-42c4-bdd4-431a691f3298.png">

I think I know what's going on here.
https://github.blog/2021-09-01-improving-git-protocol-security-github/