### PR TITLE
Fix for failure on submodule clone 

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "shFlags"]
 	path = shFlags
-	url = git://github.com/nvie/shFlags.git
+	url = https://github.com/nvie/shFlags.git


### PR DESCRIPTION
When I ran clone, it failed as follows, so I changed the URL.

<img width="869" alt="image" src="https://user-images.githubusercontent.com/11070996/161872113-2d5b2030-4a9a-4341-86a2-41336aee841f.png">

I think I know what's going on here.
https://github.blog/2021-09-01-improving-git-protocol-security-github/